### PR TITLE
ignore self and strip path prefixes

### DIFF
--- a/mavenimport.sh
+++ b/mavenimport.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# copy and run this script to the root of the repository directory containing files
+# this script attempts to exclude uploading itself explicitly so the script name is important
 # Get command line params
 while getopts ":r:u:p:" opt; do
 	case $opt in
@@ -12,4 +14,4 @@ while getopts ":r:u:p:" opt; do
 	esac
 done
 
-find . -type f -not -path '*/\.*' -not -path '*/\^archetype\-catalog\.xml*' -not -path '*/\^maven\-metadata\-local*\.xml' -not -path '*/\^maven\-metadata\-deployment*\.xml' -exec curl -u $USERNAME:$PASSWORD -X PUT -v -T {} $REPO_URL{} \;
+find . -type f -not -path './mavenimport\.sh*' -not -path '*/\.*' -not -path '*/\^archetype\-catalog\.xml*' -not -path '*/\^maven\-metadata\-local*\.xml' -not -path '*/\^maven\-metadata\-deployment*\.xml' | sed "s|^\./||" | xargs -I '{}' curl -u "$USERNAME:$PASSWORD" -X PUT -v -T {} ${REPO_URL}/{} ;


### PR DESCRIPTION
script was failing to exclude itself from upload - fixed that
script was trying to upload paths `/./some/file` instead of `/some/file` - this fails on nexus 3 - fixed that with sed